### PR TITLE
Adapted fix_braindamage.patch for grocy 3.2.0

### DIFF
--- a/grocy/rootfs/patches/fix_braindamage.patch
+++ b/grocy/rootfs/patches/fix_braindamage.patch
@@ -2,15 +2,14 @@ diff --git a/views/layout/default.blade.php b/views/layout/default.blade.php
 index 4eb3fb8d..d4e5e007 100644
 --- a/views/layout/default.blade.php
 +++ b/views/layout/default.blade.php
-@@ -88,7 +88,10 @@
- 		Grocy.Version = '{{ $version }}';
+@@ -88,6 +88,10 @@
  		Grocy.Mode = '{{ GROCY_MODE }}';
  		Grocy.BaseUrl = '{{ $U('/') }}';
-		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
+ 		Grocy.CurrentUrlRelative = "/" + window.location.href.split('?')[0].replace(Grocy.BaseUrl, "");
 +		if(Grocy.BaseUrl.indexOf('http') != 0 || Grocy.BaseUrl.indexOf('hassio_ingress') >= 0) {
 +			Grocy.BaseUrl = window.location.origin + '{{ $U('/') }}';
 +			Grocy.CurrentUrlRelative = "/" + window.location.pathname.replace(Grocy.BaseUrl, "");
 +		};
  		Grocy.ActiveNav = '@yield('activeNav', '')';
- 		Grocy.Culture = '{{ GROCY_LOCALE }}';
  		Grocy.Currency = '{{ GROCY_CURRENCY }}';
+ 		Grocy.CalendarFirstDayOfWeek = '{{ GROCY_CALENDAR_FIRST_DAY_OF_WEEK }}';


### PR DESCRIPTION
I just noticed that the [fix_braindamage.patch](https://github.com/hassio-addons/addon-grocy/blob/main/grocy/rootfs/patches/fix_braindamage.patch) patch fails due to [this](https://github.com/grocy/grocy/commit/51fdefaede79ab61be8a250f5c7b42b2e2a361ba) commit.

# Proposed Changes

> Adapted [fix_braindamage.patch](https://github.com/hassio-addons/addon-grocy/blob/main/grocy/rootfs/patches/fix_braindamage.patch) to grocy 3.2.0.

## Related Issues

> https://github.com/grocy/grocy/commit/51fdefaede79ab61be8a250f5c7b42b2e2a361ba
